### PR TITLE
DHALSIM experiment YAML files now support an option to select Epynet or WNTR as WDS simulator.

### DIFF
--- a/dhalsim/physical_process.py
+++ b/dhalsim/physical_process.py
@@ -544,7 +544,7 @@ class PhysicalPlant:
         """Runs the simulation for x iterations."""
 
         iteration_limit = self.data["iterations"]
-        self.logger.debug("Temporary file location: " + str(Path(self.data["db_path"]).parent))
+        self.logger.info("Temporary file location: " + str(Path(self.data["db_path"]).parent))
 
         if 'batch_index' in self.data:
             self.logger.info("Running batch simulation {x} out of {y}."


### PR DESCRIPTION
Minor change to show with debug level info the temporary folder